### PR TITLE
fix: Restore time-based auto-stop for practice recording

### DIFF
--- a/components/camera-module.tsx
+++ b/components/camera-module.tsx
@@ -74,7 +74,15 @@ export function CameraModule({ selectedLabel, onPredictionComplete }: CameraModu
           clearInterval(countdownRef.current!)
           setIsRecording(true)
 
-          // Recording duration is now handled by NUM_FRAMES and useEffect
+          // Recording starts: set a timer for 3 seconds to automatically stop and submit.
+          // Frames will be collected up to NUM_FRAMES (35) within this period.
+          if (recordingRef.current) {
+            clearTimeout(recordingRef.current); // Clear any existing timer
+          }
+          recordingRef.current = setTimeout(() => {
+            setIsRecording(false);
+            submitRecording();
+          }, 3000); // 3-second recording duration
           return null
         }
         return prev - 1
@@ -135,15 +143,6 @@ export function CameraModule({ selectedLabel, onPredictionComplete }: CameraModu
       setIsRecording(false) // Safeguard
     }
   }, [selectedLabel, frames, predict, onPredictionComplete, setFrames, toast]) // NUM_FRAMES & NUM_FEATURES are constants
-
-  // Effect to automatically stop recording when NUM_FRAMES are collected.
-  // This ensures submission happens once exactly NUM_FRAMES are collected.
-  useEffect(() => {
-    if (isRecording && frames.length === NUM_FRAMES) {
-      setIsRecording(false) // Stop recording UI indication
-      submitRecording() // Call the existing submitRecording function
-    }
-  }, [frames, isRecording, submitRecording]) // Added submitRecording
 
   // Clean up on unmount
   useEffect(() => {


### PR DESCRIPTION
This commit addresses the issue where the recording on the /practice page would not stop automatically ("stuck on Grabando..."). The recording logic in `components/camera-module.tsx` has been reverted to a time-based auto-stop mechanism as per your request.

Key changes:
- Re-introduced a 3-second `setTimeout` in the `startRecording` function. When this timer elapses, `isRecording` is set to `false` and `submitRecording()` is called.
- Removed the `useEffect` hook that previously triggered submission based on collecting a fixed number of frames (`NUM_FRAMES`).
- The `handleFrame` function continues to cap the collected frames at `NUM_FRAMES` (35).
- The `submitRecording` function will use these collected frames (up to 35) if available and valid, or fall back to a 35x42 dummy matrix, ensuring the payload for `/api/predict` remains consistent.
- Verified that all relevant timers are properly cleared.
- Updated comments to reflect the restored time-based logic.

This change ensures that practice recordings automatically conclude after approximately 3 seconds, after which the prediction process is initiated, restoring the intended user experience.