### PR TITLE
fix: Update Label interface for potential 'sequence' field

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -36,6 +36,7 @@ export interface Label {
   description: string
   category: string
   difficulty: "beginner" | "intermediate" | "advanced"
+  sequence?: any[]; // Optional: A sequence associated with the label, structure might vary or be undefined.
 }
 
 export interface PredictionRecord {


### PR DESCRIPTION
This commit addresses the TypeError "Cannot read properties of undefined (reading 'length')" reported on /labels and /practice pages.

Based on your feedback that /api/labels returns data but rendering fails, and the hypothesis that an optional 'sequence' field on Label objects might be causing issues if accessed without checks:

1.  **Updated `Label` Interface (`lib/api.ts`):**
    *   The `Label` interface now includes `sequence?: any[];` with a comment
      `// Optional: A sequence associated with the label, structure might
      // vary or be undefined.`
    *   This change makes the frontend type definition more accurately reflect
      the potential data structure coming from the backend, where 'sequence'
      might be an optional or inconsistently present field.

No direct access to `label.sequence.length` was found in the primary rendering components (`LabelCard`, `app/labels/page.tsx`, `app/practice/page.tsx`). The exact location of the error needs to be pinpointed using browser developer tools by pausing on the exception. This interface update is a preparatory step.

Further action to add specific guards in the rendering code will be taken once the precise location of the error is identified through debugging.